### PR TITLE
Make the gemfast cmd run server if no subcommand is provided.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp
 !test/fixtures/spec/*.gem
 dist/
 bin/
+.vercel
+.env*

--- a/cmd/gemfast-server/root.go
+++ b/cmd/gemfast-server/root.go
@@ -9,6 +9,10 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "gemfast-server",
 	Short: "Gemfast is a rubygems server written in Go",
+	// When invoked with no subcommand, default to running the server (same as "start").
+	Run: func(cmd *cobra.Command, args []string) {
+		start()
+	},
 }
 
 func Execute() {

--- a/cmd/gemfast-server/start.go
+++ b/cmd/gemfast-server/start.go
@@ -27,6 +27,9 @@ var configPath string
 
 func init() {
 	startCmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to the config file")
+	// Expose the same flag on the root command so it works when invoking
+	// gemfast-server with no subcommand (defaults to start).
+	rootCmd.Flags().StringVarP(&configPath, "config", "c", "", "Path to the config file")
 	rootCmd.AddCommand(startCmd)
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -46,6 +47,11 @@ func (api *API) Run() {
 	api.loadMiddleware()
 	api.registerRoutes()
 	port := fmt.Sprintf(":%d", api.cfg.Port)
+	// Honor the PORT env var (e.g. injected by Vercel) when set, falling back
+	// to the configured/default port otherwise.
+	if p := os.Getenv("PORT"); p != "" {
+		port = ":" + p
+	}
 	if api.cfg.Mirrors[0].Enabled {
 		log.Info().Str("detail", api.cfg.Mirrors[0].Upstream).Msg("mirroring upstream gem server")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"runtime"
 
 	"github.com/gemfast/server/internal/utils"
 	"github.com/hashicorp/hcl/v2/hclsimple"
@@ -125,16 +124,10 @@ func (c *Config) setDefaultServerConfig() {
 	}
 	configureLogLevel(c.LogLevel)
 	if c.Dir == "" {
-		if c.user.Username == "root" {
-			c.Dir = "/var/lib/gemfast/data"
-		} else if runtime.GOOS == "darwin" {
-			c.Dir = fmt.Sprintf("%s/Library/Application Support/gemfast", c.user.HomeDir)
-		} else if runtime.GOOS == "linux" {
-			c.Dir = fmt.Sprintf("%s/gemfast", os.Getenv("XDG_DATA_HOME"))
-			if c.Dir == "/gemfast" {
-				c.Dir = fmt.Sprintf("%s/.local/share/gemfast", c.user.HomeDir)
-			}
-		}
+		// NOTE: hardcoded to /tmp for the Vercel test deployment, where /tmp
+		// is the only writable location. This is intentionally not
+		// platform-specific for now.
+		c.Dir = "/tmp/gemfast"
 	}
 	if c.GemDir == "" {
 		c.GemDir = fmt.Sprintf("%s/gems", c.Dir)


### PR DESCRIPTION
Platforms like vercel don't support passing a subcommand (yet) so default to running the server command.